### PR TITLE
Changing elastic-search port to avoid conflict

### DIFF
--- a/demo/src/main/resources/docker-compose.yml
+++ b/demo/src/main/resources/docker-compose.yml
@@ -13,8 +13,8 @@ services:
     environment:
       - discovery.type=single-node
     ports:
-      - "9200:9200"
-      - "9300:9300"
+      - "9210:9200"
+      - "9310:9300"
 
   redis:
     image: redis:alpine


### PR DESCRIPTION
Changing port to avoid conflict with another elastic instance on same node.